### PR TITLE
Fix syntax errors in the OWL representation of MOD 2.0

### DIFF
--- a/mod-v2.0_ontology.owl
+++ b/mod-v2.0_ontology.owl
@@ -2978,8 +2978,8 @@ dcterms:accrualPolicy
 ### https://w3id.org/mod#SemanticArtefact
 mod:SemanticArtefact 
                     rdf:type                owl:Class ;
-                    rdfs:label              "Semantic Artefact"@en .
-                    rdfs:comment "A specification of a conceptualization that may be represented by different levels of formalization (including controlled lists, thesauri and ontologies - either lightweight or heavyweight."@en ;           
+                    rdfs:label              "Semantic Artefact"@en ;
+                    rdfs:comment "A specification of a conceptualization that may be represented by different levels of formalization (including controlled lists, thesauri and ontologies - either lightweight or heavyweight."@en .           
 
 
 ### https://w3id.org/mod#Analytics


### PR DESCRIPTION
This pull request fixes two minor syntax errors in the OWL representation of MOD 2.0. The syntax errors prevented the OWL file from loading in the Protege ontology editor, or programmatically via the OWL API. Thanks go to @biswanathdutta for pointing out the necessary corrections. Resolves #62.